### PR TITLE
Update install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cd lowpolypy
 Install dependencies:
 
 ```bash
-pip install -r requirements.txt
+pip install .
 ```
 
 ### Try It Out


### PR DESCRIPTION
The project uses pyproject.toml now. This change isn't updated in the install instructions.